### PR TITLE
Quick fixes typo

### DIFF
--- a/VX-API/GetCurrentProcessIdFromOffset.cpp
+++ b/VX-API/GetCurrentProcessIdFromOffset.cpp
@@ -4,7 +4,7 @@ DWORD GetCurrentProcessIdFromOffset(VOID)
 {
 #if defined(_WIN64)
     return (UINT32)__readgsqword(0x40);
-#elif define(_WIN32)
+#elif defined(_WIN32)
     return (UINT32)__readfsdword(0x20);
 #endif
 }

--- a/VX-API/GetPeb.cpp
+++ b/VX-API/GetPeb.cpp
@@ -4,7 +4,7 @@ PPEB GetPeb(VOID)
 {
 #if defined(_WIN64)
 	return (PPEB)__readgsqword(0x60);
-#elif define(_WIN32)
+#elif defined(_WIN32)
 	return (PPEB)__readfsdword(0x30);
 #endif
 }
@@ -14,7 +14,7 @@ PPEB GetPebFromTeb(VOID)
 	PTEB Teb;
 #if defined(_WIN64)
 	Teb = (PTEB)__readgsqword(0x30);
-#elif define(_WIN32)
+#elif defined(_WIN32)
 	Teb = (PTEB)__readfsdword(0x18);
 #endif
 	return (PPEB)Teb->ProcessEnvironmentBlock;


### PR DESCRIPTION
This commit fixes 3 typo errors about macro _WIN32 check in `GetPeb.cpp` & `GetCurrentProcessIdFromOffset.cpp` files